### PR TITLE
Transform the add_matching_mesh subroutine 

### DIFF
--- a/src/bindings/c/geometry.c
+++ b/src/bindings/c/geometry.c
@@ -3,7 +3,7 @@
 
 #include "string.h"
 
-void add_matching_mesh_c(const char *umbilical_elem_option, int *umbilical_elem_option_len, const char *UMB_ELEMS_FILE, int *filename_len);
+extern void add_matching_mesh_c(const char *umbilical_elem_option, int *umbilical_elem_option_len, int umbilical_element_numbers[], int *umbilical_element_numbers_len);
 void append_units_c();
 void calc_capillary_unit_length_c(int *num_convolutes, int *num_generations);
 void define_1d_elements_c(const char *ELEMFILE, int *filename_len);
@@ -17,11 +17,10 @@ void element_connectivity_1d_c();
 void evaluate_ordering_c();
 
 
-void add_matching_mesh(const char *umbilical_elem_option, const char *UMB_ELEMS_FILE)
+void add_matching_mesh(const char *umbilical_elem_option, int umbilical_element_numbers_len, int umbilical_element_numbers[])
 {
   int umbilical_elem_option_len = strlen(umbilical_elem_option);
-  int filename_len = strlen(UMB_ELEMS_FILE);	
-  add_matching_mesh_c(umbilical_elem_option, &umbilical_elem_option_len, UMB_ELEMS_FILE, &filename_len);
+  add_matching_mesh_c(umbilical_elem_option, &umbilical_elem_option_len, umbilical_element_numbers, &umbilical_element_numbers_len);
 }
 
 void append_units()

--- a/src/bindings/c/geometry.f90
+++ b/src/bindings/c/geometry.f90
@@ -8,25 +8,23 @@ contains
 !
 !*add_matching_mesh:* Replicates an existing mesh, continuing node and element numbers
   subroutine add_matching_mesh_c(umbilical_elem_option,umbilical_elem_option_len, &
-        UMB_ELEMS_FILE,filename_len) bind(C, name="add_matching_mesh_c")
+        umbilical_element_numbers, umbilical_element_numbers_len) bind(C, name="add_matching_mesh_c")
     use iso_c_binding, only: c_ptr
     use utils_c, only: strncpy
     use other_consts, only: MAX_STRING_LEN,MAX_FILENAME_LEN
     use geometry, only: add_matching_mesh
     implicit none
 
-    integer,intent(in) :: umbilical_elem_option_len, filename_len
-    type(c_ptr), value, intent(in) :: umbilical_elem_option,UMB_ELEMS_FILE
+    integer,intent(in) :: umbilical_elem_option_len, umbilical_element_numbers_len
+    type(c_ptr), value, intent(in) :: umbilical_elem_option
     character(len=MAX_STRING_LEN) :: umbilical_elem_option_f
-    character(len=MAX_FILENAME_LEN) :: filename_f  
-    !integer,intent(in) :: umbilical_elems(20)
+    integer,intent(in) :: umbilical_element_numbers(umbilical_element_numbers_len)
 
     call strncpy(umbilical_elem_option_f, umbilical_elem_option, umbilical_elem_option_len)
-    call strncpy(filename_f, UMB_ELEMS_FILE, filename_len)
 #if defined _WIN32 && defined __INTEL_COMPILER
-    call so_add_matching_mesh(umbilical_elem_option_f, filename_f)
+    call so_add_matching_mesh(umbilical_elem_option_f, umbilical_element_numbers)
 #else
-    call add_matching_mesh(umbilical_elem_option_f, filename_f)
+    call add_matching_mesh(umbilical_elem_option_f, umbilical_element_numbers)
 #endif
 
   end subroutine add_matching_mesh_c

--- a/src/bindings/c/geometry.h
+++ b/src/bindings/c/geometry.h
@@ -4,7 +4,7 @@
 
 #include "symbol_export.h"
 
-SHO_PUBLIC void add_matching_mesh(const char *umbilical_elem_option, const char *UMB_ELEMS_FILE);
+SHO_PUBLIC void add_matching_mesh(const char *umbilical_elem_option, int umbilical_element_numbers_len, int umbilical_element_numbers[]);
 SHO_PUBLIC void append_units();
 SHO_PUBLIC void calc_capillary_unit_length(int num_convolutes, int num_generations);
 SHO_PUBLIC void define_1d_elements(const char *ELEMFILE);

--- a/src/bindings/interface/geometry.i
+++ b/src/bindings/interface/geometry.i
@@ -2,13 +2,35 @@
 %module(package="reprosim") geometry
 %include symbol_export.h
 
+%typemap(in) (int umbilical_element_numbers_len, int umbilical_element_numbers[]) {
+  int i;
+  if (!PyList_Check($input)) {
+    PyErr_SetString(PyExc_ValueError, "Expecting a list");
+    SWIG_fail;
+  }
+  $1 = PyList_Size($input);
+  $2 = (int *) malloc(($1)*sizeof(int));
+  for (i = 0; i < $1; i++) {
+    PyObject *o = PyList_GetItem($input, i);
+    if (!PyInt_Check(o)) {
+      free($2);
+      PyErr_SetString(PyExc_ValueError, "List items must be integers");
+      SWIG_fail;
+    }
+    $2[i] = PyInt_AsLong(o);
+  }
+}
+
+%typemap(freearg) (int umbilical_element_numbers_len, int umbilical_element_numbers[]) {
+  if ($2) free($2);
+}
+
 %{
 #include "geometry.h"
 %}
 
 // define_rad_from_file has an optional argument that C cannot replicate,
 // so we use SWIG to override with a C++ version that can.
-void add_matching_mesh(const char *umbilical_elem_option, const char *UMB_ELEMS_FILE="");
 void define_rad_from_file(const char *FIELDFILE, const char *order_system="strahler", double s_ratio=1.54);
 void define_rad_from_geom(const char *ORDER_SYSTEM, double CONTROL_PARAM, const char *START_FROM, double START_RAD, const char *group_type_in="all", const char *group_option_in="dummy");
 

--- a/src/lib/geometry.f90
+++ b/src/lib/geometry.f90
@@ -27,7 +27,7 @@ contains
 !
 !###################################################################################
 !
-  subroutine add_matching_mesh(umbilical_elem_option_in, UMB_ELEMS_FILE)
+  subroutine add_matching_mesh(umbilical_elem_option_in, umbilical_element_numbers)
   !*Description:* adds a matching venous mesh to an arterial mesh.
   ! Two options are availabe: 1) 'same_as_arterial' - the venous vessels
   ! are an exact copy of the arterial vessels. 2) 'single_umbilical_vein' -
@@ -46,7 +46,7 @@ contains
   !DEC$ ATTRIBUTES DLLEXPORT,ALIAS:"SO_ADD_MATCHING_MESH" :: ADD_MATCHING_MESH 
     character(len=MAX_STRING_LEN),intent(in) ::  umbilical_elem_option_in  !argument controlling how the umbilical 
     !venous elements are created, 'same_as_arterial' or 'single_umbilical_vein'
-    character(len=MAX_FILENAME_LEN), optional :: UMB_ELEMS_FILE   !file containing a list of umbilical artery element numbers 
+    integer, intent(in), optional :: umbilical_element_numbers(:)  !list containing umbilical artery element numbers
     !Parameters to become inputs
     real(dp) :: offset(3)
     logical :: REVERSE=.TRUE.
@@ -66,6 +66,7 @@ contains
     integer :: umb_ven_nodes(4) = 0 !umbilical venous nodes
     integer, allocatable :: umb_art_nodes(:)
     integer :: umbilical_elems(20) = 0
+    integer :: index
     character(LEN=132) :: ctemp1
 
     character(len=60) :: sub_name
@@ -83,25 +84,11 @@ contains
     endif
 
     !if((umbilical_elem_option_in.EQ.'single_umbilical_vein').AND.(len(UMB_ELEMS_FILE).GT.0))then
-    if((umbilical_elem_option_in.EQ.'single_umbilical_vein').AND.(present(UMB_ELEMS_FILE)).AND.(UMB_ELEMS_FILE.NE.""))then
-       open(10, file=UMB_ELEMS_FILE, status='old')
-       umb_elem_indx = 0
-       read_umb_element : do  
-          read(unit=10, fmt="(a)", iostat=ierror) ctemp1
-          
-             if(ierror.GT.0)then
-                print *, "Error reading umbilical elements file", UMB_ELEMS_FILE
-                call exit(1)
-	     elseif(ierror.LT.0)then
-                exit read_umb_element
-             else
-                read (ctemp1, '(i10)' ) ntemp 
-                umb_elem_indx = umb_elem_indx + 1 
-                umbilical_elems(umb_elem_indx) = ntemp
-	     endif
-       end do read_umb_element
-       close(10)
+    if((umbilical_elem_option_in.EQ.'single_umbilical_vein').AND.(size(umbilical_element_numbers).GT.0))then
 
+       do index = 1, size(umbilical_element_numbers)
+          umbilical_elems(index) = umbilical_element_numbers(index)
+       enddo
        if(diagnostics_level.GT.1)then
           print *, "umbilical_elems", umbilical_elems
        endif


### PR DESCRIPTION
The add_matching_mesh subroutine should take a 1D array of integers as the second argument.